### PR TITLE
Added text overlay support for mobile slideshow

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -6563,7 +6563,7 @@ hr {
   .slideshow__text-wrap--mobile {
     display: block;
     position: relative;
-    top: -1.1rem;
+    top: 3px;
     background-color: var(--color-bg);
     width: 85%;
     margin: 0 0 -1.1rem 7.5%;
@@ -6619,7 +6619,7 @@ hr {
 }
 
 .slideshow__text-content--mobile {
-  display: none;
+  display: none !important;
   padding-top: 2.6rem;
 }
 .slideshow__arrows--mobile ~ .slideshow__text-content--mobile {
@@ -6650,7 +6650,7 @@ hr {
 @media only screen and (max-width: 749px) {
   .slideshow__title,
   .slideshow__subtitle {
-    display: none;
+    display: block;
   }
 }
 
@@ -6695,7 +6695,7 @@ hr {
 }
 @media only screen and (max-width: 749px) {
   .slideshow__btn {
-    display: none;
+    margin: 1rem auto 0.3rem;
   }
 }
 
@@ -6722,9 +6722,7 @@ hr {
 }
 @media only screen and (min-width: 750px) {
   .slideshow__controls {
-    top: auto;
-    bottom: 0;
-    left: 0;
+    display: none;
   }
 }
 


### PR DESCRIPTION
Added support for an overlaid text and button content on the slideshow when using mobile device.

Normally this content would sit below the slideshow.

![View screenshot at the following link: https://screenshot.click/21-03-kob7f-2ril8.png](https://screenshot.click/21-03-kob7f-2ril8.png)