### PR TITLE
Add support for transparent header homepage logo

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -4931,6 +4931,7 @@ hr {
 .site-header__logo {
   margin: 15px 0;
 }
+
 .logo-align--center .site-header__logo {
   text-align: center;
   margin: 0 auto;

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,3 +1,13 @@
+{% comment %}
+Capture the logo image to use as a variable we can pass down
+to the header-logo snippet file
+{% endcomment %}
+{% if template == 'index' and section.settings.transparent_header_logo and section.settings.transparent_header %}
+  {% assign header_logo = section.settings.transparent_header_logo %}
+{% else %}
+  {% assign header_logo = section.settings.logo %}
+{% endif %}
+
 {% if section.settings.transparent_header %}
   {% if template == 'index' %}
     <style>
@@ -118,25 +128,12 @@
           <div class="h2 site-header__logo">
         {% endif %}
           {% if section.settings.logo %}
-            {%- assign img_url = section.settings.logo | img_url: '1x1' | replace: '_1x1.', '_{width}x.' -%}
-            <a href="{{ routes.root_url }}" class="site-header__logo-image{% if section.settings.align_logo == 'center' %} site-header__logo-image--centered{% endif %}" data-image-loading-animation>
-              {% capture logo_alt %}{{ section.settings.logo.alt | default: shop.name }}{% endcapture %}
-              <img class="lazyload js"
-                   src="{{ section.settings.logo | img_url: '300x300' }}"
-                   data-src="{{ img_url }}"
-                   data-widths="[180, 360, 540, 720, 900, 1080, 1296, 1512, 1728, 2048]"
-                   data-aspectratio="{{ section.settings.logo.aspect_ratio }}"
-                   data-sizes="auto"
-                   alt="{{ logo_alt | escape }}"
-                   style="max-width: {{ section.settings.logo_max_width }}px">
-              <noscript>
-                {% capture image_size %}{{ section.settings.logo_max_width | escape }}x{% endcapture %}
-                <img src="{{ section.settings.logo | img_url: image_size }}"
-                     srcset="{{ section.settings.logo | img_url: image_size }} 1x, {{ section.settings.logo | img_url: image_size, scale: 2 }} 2x"
-                     alt="{{ section.settings.logo.alt | default: shop.name }}"
-                     style="max-width: {{ section.settings.logo_max_width }}px;">
-              </noscript>
-            </a>
+            <div class="site-header__logo-desktop small--hide">
+              {% render 'header-logo' with logo: header_logo, max_width: section.settings.logo_max_width, align_logo: section.settings.align_logo %}
+            </div>
+            <div class="site-header__logo-mobile medium-up--hide">
+              {% render 'header-logo' with logo: section.settings.logo, max_width: section.settings.logo_max_width, align_logo: section.settings.align_logo %}
+            </div>
           {% else %}
             <a class="site-header__logo-link" href="{{ routes.root_url }}">{{ shop.name }}</a>
           {% endif %}
@@ -537,6 +534,11 @@
       "id": "transparent_header",
       "label": "Transparent homepage header",
       "default": true
+    },
+    {
+      "type": "image_picker",
+      "id": "transparent_header_logo",
+      "label": "Transparent homepage logo"
     },
     {
       "type": "color",

--- a/snippets/header-logo.liquid
+++ b/snippets/header-logo.liquid
@@ -1,0 +1,19 @@
+{%- assign img_url = logo | img_url: '1x1' | replace: '_1x1.', '_{width}x.' -%}
+<a href="{{ routes.root_url }}" class="site-header__logo-image{% if align_logo == 'center' %} site-header__logo-image--centered{% endif %}" data-image-loading-animation>
+    {% capture logo_alt %}{{ logo.alt | default: shop.name }}{% endcapture %}
+    <img class="lazyload js"
+        src="{{ logo | img_url: '300x300' }}"
+        data-src="{{ img_url }}"
+        data-widths="[180, 360, 540, 720, 900, 1080, 1296, 1512, 1728, 2048]"
+        data-aspectratio="{{ logo.aspect_ratio }}"
+        data-sizes="auto"
+        alt="{{ logo_alt | escape }}"
+        style="max-width: {{ max_width }}px">
+    <noscript>
+        {% capture image_size %}{{ max_width | escape }}x{% endcapture %}
+        <img src="{{ logo | img_url: image_size }}"
+            srcset="{{ logo | img_url: image_size }} 1x, {{ logo | img_url: image_size, scale: 2 }} 2x"
+            alt="{{ logo.alt | default: shop.name }}"
+            style="max-width: {{ max_width }}px;">
+    </noscript>
+</a>


### PR DESCRIPTION
Adds in a new snippet file which contains the code for the header logo. This can then have different image sources assigned to it depending on the current theme settings.

This allows for a specific logo to be used on the homepage when the transparent header setting is enabled that is different from other pages on the theme where the transparent header doesn't exist.

Fixes bug reporting in issue https://github.com/jonas-henehan/theme-development/issues/5 where the example white logo doesn't show on the white background of the header on non-index pages